### PR TITLE
Fix Issue #1: Don't crash when triangulating too few points

### DIFF
--- a/Graphics/Triangulation/Delaunay.hs
+++ b/Graphics/Triangulation/Delaunay.hs
@@ -21,7 +21,10 @@ import Data.List
 -- | Generate the Delaunay triangulation of a set of points
 triangulate :: [Vector2] -> [(Vector2,Vector2,Vector2)]
 triangulate [] = []
-triangulate pts' = map (\(Pt a,Pt b,Pt c) -> (a,b,c)) $ triangulationToTris $ removeHelperPoints pts trig
+triangulate pts' = 
+  case pts of
+    (_:_:_:_) -> map (\(Pt a,Pt b,Pt c) -> (a,b,c)) $ triangulationToTris $ removeHelperPoints pts trig
+    _tooFew   -> []
   where trig = addPoints (baseTriangulation pts) pts
         pts  = map Pt $ nub pts'
         


### PR DESCRIPTION
This was a quick patch to prevent the "triangulate" function crashing when given too few points (or too few distinct points).  I see head's being called much deeper in the algorithm -  Perhaps you'll prefer to fix it there.

Regarding my implementation: I'm not sure of the preferred way to check the list length is at least 3.  I did it with pattern matching, to avoid calling length, for performance.

I'll send a separate pull request with the corresponding unit tests: I have them locally but didn't include them here as you may not want to add the HUnit dependency.
