### PR TITLE
Add tests/Tests.hs and integrate with cabal. 

### DIFF
--- a/delaunay.cabal
+++ b/delaunay.cabal
@@ -24,3 +24,15 @@ library
                      , AC-Vector >= 2.2.0
                      , unordered-containers >= 0.2.1.0
                      , hashable >= 1.0.1.1
+
+Test-Suite           delaunay-testsuite
+  Type:              exitcode-stdio-1.0
+  hs-source-dirs:    tests
+  Main-is:           Tests.hs
+
+  Build-depends:       base >= 4 && <5
+                     , AC-Vector >= 2.2.0
+                     , delaunay
+                     , QuickCheck >= 2.4.0.0
+                     , HUnit >= 1.2.0.0
+

--- a/tests/PropertyTestsUnused.hs
+++ b/tests/PropertyTestsUnused.hs
@@ -1,0 +1,40 @@
+{-# LANGUAGE TemplateHaskell #-} -- for quickCheckAll
+module Main where
+
+-- import Test.Framework (Test, defaultMain, testGroup)
+import Control.Applicative ((<$>), (<*>))
+import Control.Monad (unless)
+import Data.List (nub)
+import Data.Vector.V2
+import System.Exit (exitFailure)
+import Test.QuickCheck
+import Test.QuickCheck.All (quickCheckAll)
+
+-- modules under test
+import Graphics.Triangulation.Delaunay (triangulate)
+ 
+hasDistinctPoints :: (Vector2, Vector2, Vector2) -> Bool
+hasDistinctPoints (p1,p2,p3) = p1/=p2 && p1/=p2 && p2/=p3
+
+-- this instance makes rounded-value points for 
+-- test-data readability.
+instance Arbitrary Vector2
+  where arbitrary = do 
+          let r :: Int -> Double
+              r = fromIntegral
+          Vector2 <$> fmap r arbitrary <*> fmap r arbitrary
+
+prop_nodups ::  [Vector2] -> Property
+prop_nodups pts =
+    (length (nub pts) >= 3)  ==>
+    -- TODO: reject colinear points
+        all hasDistinctPoints (triangulate pts) 
+      
+ 
+runTests ::  IO Bool
+runTests = $quickCheckAll
+
+main ::  IO ()
+main = do
+  result <- runTests
+  unless result exitFailure

--- a/tests/Tests.hs
+++ b/tests/Tests.hs
@@ -1,0 +1,41 @@
+module Main where
+import Test.HUnit(Counts(..),Test(..),runTestTT,(~?=),(~:))
+import Control.Monad (unless)
+import Data.Vector.V2
+import System.Exit (exitFailure)
+
+-- modules under test
+import Graphics.Triangulation.Delaunay (triangulate)
+
+-- TODO: use test-framework
+success :: Counts -> Bool
+success cs = errors cs == 0 && failures cs == 0
+
+tests ::  IO Counts
+tests = runTestTT $ TestList 
+  [ fewPointsTests
+  , triPointsAreDistinctTests
+  ]
+
+fewPointsTests = TestList 
+  [ "triangulate no points"  ~: triangulate []                     ~?= []
+  , "triangulate one point"  ~: triangulate [v2 1 1]               ~?= []
+  , "triangulate two points" ~: triangulate [v2 1 1, v2 2 2]       ~?= []
+  , "triangulate many dups"  ~: triangulate (replicate 5 (v2 1 1)) ~?= []
+  ]
+  where
+    v2 = Vector2 
+
+triPointsAreDistinctTests = TestList 
+  [ "each tri has distinct pts" ~: filter (not . hasDistinctPoints) (triangulate pts) ~?= []
+  ]
+  where 
+    pts = [v 0 7, v 24 33, v 10 13, v 20 0, v 22 11] where v = Vector2
+
+hasDistinctPoints :: (Vector2, Vector2, Vector2) -> Bool
+hasDistinctPoints (p1,p2,p3) = p1/=p2 && p1/=p3 && p2/=p3
+
+main = do
+  result <- tests
+  unless (success result) exitFailure
+


### PR DESCRIPTION
Add failing (HUnit) tests for issues #1 and #4.
Integrated with cabal test using exitcode-stdio.

Also added a properties-based test for #4 but didn't 
hook it up to cabal as it currently produces some 
false positives (e.g. when points are colinear).
Hopefully useful as a base for you.

Neither uses test-framework yet (as I had problems
 installing it), but that'd be desirable as the suite grows.
